### PR TITLE
Remove extra parameter in function call

### DIFF
--- a/src/tools/aws_uploader/scripts/directory_uploader.py
+++ b/src/tools/aws_uploader/scripts/directory_uploader.py
@@ -43,7 +43,7 @@ def main():
 
     if not os.path.exists(directory_path):
         if is_create_directory_if_doesnt_exist:
-            os.makedirs(directory_path, exist_ok=True)
+            os.makedirs(directory_path)
         else:
             raise IOError("Directory doesn't exist: '{}'".format(directory_path))
     if not os.path.isdir(directory_path):


### PR DESCRIPTION
I've removed the parameter `exist_ok=True` in the directory uploader, as it causes an error when using Python 2.7: https://github.com/robotpt/ros-data-capture/blob/9819e6ab55e19578906a9547c3edd5f81b6e621d/src/tools/aws_uploader/scripts/directory_uploader.py#L44-L46
