### PR TITLE
Add parameter to prepend the audio file name with

### DIFF
--- a/src/data_capture/audio_capture2/launch/capture.launch
+++ b/src/data_capture/audio_capture2/launch/capture.launch
@@ -11,6 +11,7 @@
     <arg name="chunk_size" default="1024"/>
     <arg name="sample_rate" default="16000"/>
     <arg name="format" default="wave"/>
+    <arg name="file_name_prefix" default="''"/>
 
     <group if="$(eval is_launch_audio_capture)">
         <include file="$(find audio_capture)/launch/capture.launch">
@@ -28,9 +29,10 @@
             --is-record-topic $(arg is_record_topic)
             --output-directory $(arg output_directory)
             --num-channels $(arg num_channels)
-            --chunk_size $(arg chunk_size)
-            --sample_rate $(arg sample_rate)
+            --chunk-size $(arg chunk_size)
+            --sample-rate $(arg sample_rate)
             --format $(arg format)
+            --file-name-prefix $(arg file_name_prefix)
         "
         />
 

--- a/src/data_capture/audio_capture2/scripts/capture.py
+++ b/src/data_capture/audio_capture2/scripts/capture.py
@@ -23,6 +23,7 @@ class AudioCapture:
             sample_rate,
             chunk_size,
             format_size,
+            file_name_prefix='',
             out_file_directory='audio',
     ):
 
@@ -35,6 +36,10 @@ class AudioCapture:
         self._sample_rate = sample_rate
         self._chunk_size = chunk_size
         self._format_size = format_size
+        self._file_name_prefix = file_name_prefix
+        if len(self._file_name_prefix) > 0:
+            self._file_name_prefix += '_'
+        rospy.loginfo(self._file_name_prefix)
         self._out_directory = out_file_directory
 
         self._start_record_datetime = None
@@ -77,7 +82,8 @@ class AudioCapture:
 
         if not os.path.exists(self._out_directory):
             os.makedirs(self._out_directory)
-        file_name = "{date_str}.{ext}".format(
+        file_name = "{prefix}{date_str}.{ext}".format(
+            prefix=self._file_name_prefix,
             date_str=datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'),
             ext='wav'
         )
@@ -112,6 +118,10 @@ if __name__ == "__main__":
                         default="wave")
     parser.add_argument('--format-size', help='The format encoding used by PyAudio',
                         default=pyaudio.paInt16)
+    parser.add_argument('--file-name-prefix',
+                        type=str,
+                        help='The string to prepend to the file name; for example, \'evaluation\'',
+                        default='')
 
     args, _ = parser.parse_known_args()
 
@@ -125,5 +135,6 @@ if __name__ == "__main__":
         sample_rate=args.sample_rate,
         chunk_size=args.chunk_size,
         format_size=args.format_size,
+        file_name_prefix=args.file_name_prefix
     )
     rospy.spin()


### PR DESCRIPTION
Fixed #17. Adds the option to pass a file name prefix to the audio capture node, so that different types of recordings can be easily differentiated. 

For example, the vision project has different interactions: scheduled, reading evaluation, and prompted. By adding 'scheduled', 'evaluation' or 'prompted' before the datetime string, we can easily identify which recording is for which interaction.