### PR TITLE
Specify format arg

### DIFF
--- a/src/data_capture/audio_capture2/launch/capture.launch
+++ b/src/data_capture/audio_capture2/launch/capture.launch
@@ -2,11 +2,13 @@
 
     <arg name="is_launch_audio_capture" default="true"/>
     <arg name="device" default=""/>
+    <arg name="format" default="wave"/>
     <arg name="instance_id" default="1"/>
 
     <group if="$(eval is_launch_audio_capture)">
         <include file="$(find audio_capture)/launch/capture.launch">
             <arg name="device" default="$(arg device)"/>
+            <arg name="format" default="$(arg format)"/>
             <arg name="ns" default="audio"/>
         </include>
     </group>


### PR DESCRIPTION
The ROS audio_capture's default format is mp3, which caused issues with the recording. Passing in 'wave' as the format argument prevents that.